### PR TITLE
Switch from creating a symlink to LD_LIBRARY_PATH

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = cura2-lulzbot
 	pkgdesc = This is the development version of Cura 2 for LulzBot 3D Printers by Aleph Objects, Inc.
 	pkgver = 2.6.66
-	pkgrel = 1
+	pkgrel = 2
 	url = https://code.alephobjects.com
 	arch = x86_64
 	license = AGPLv3

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Kevin McCormack <harlemsquirrel@gmail.com>
 pkgname=cura2-lulzbot
 pkgver=2.6.66
-pkgrel=1
+pkgrel=2
 pkgdesc='This is the development version of Cura 2 for LulzBot 3D Printers by Aleph Objects, Inc.'
 arch=('x86_64')
 url='https://code.alephobjects.com'
@@ -15,11 +15,7 @@ prepare() {
   # where all the essentials reside within the debian package
   tar zxf "${srcdir}/data.tar".gz -C "${srcdir}"
 
-  if [ ! -e /usr/lib/libgfortran.so.3 ]; then
-    # Set up link for libgfortran that cura-lulzbot will look for
-    printf "We need sudo access to set up symlink for libgfortran \n"
-    sudo ln -sf /usr/lib/gcc/x86_64-pc-linux-gnu/6.4.1/libgfortran.so /usr/lib/libgfortran.so.3
-  fi
+  sed -i 's;LD_LIBRARY_PATH=;LD_LIBRARY_PATH=/usr/lib/gcc/x86_64-pc-linux-gnu/6.4.1:;' "${srcdir}/usr/bin/cura-lulzbot"
 }
 
 package() {


### PR DESCRIPTION
Instead of creating a symlink, we can change the LD_LIBRARY_PATH to load the specific gfortran shared object.

PS. Even if you want to create a symlink, you should do it as part of the `package()` step, using `$pkgdir`. In this case something like this:

    ln -s /usr/lib/gcc/x86_64-pc-linux-gnu/6.4.1/libgfortran.so $pkgdir/usr/lib/libgfortran.so.3

That way the symlink is part of the package, and will we installed/removed with it. The way you did, when you create the package the symlink is created, but no package owns it, and it will never be removed (check `pacman -Qo` on the file in your filesystem). 

PPS, thanks for getting this to work in the first place.